### PR TITLE
Add scopes in JWT and strict authorization; fix jwtPassport middlewar…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
+- Added `scopes` in JWT claims to handle API Authorization.
+- Added `ForbiddenError` to handle API Authorization Error.
+
 ### Changed
+
+- Changed `login-user+v1.json` schema to support `scopes` property in request payload
+
+### Fixed
+
+- Fixed wrong-working `jwtPassport` middleware.
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dotenv": "^7.0.0",
     "express": "^4.16.4",
     "jsonwebtoken": "^8.5.1",
+    "lodash": "^4.17.11",
     "moment": "^2.24.0",
     "mongoose": "^5.5.5",
     "passport": "^0.4.0",

--- a/resources/schemas/login-user+v1.js
+++ b/resources/schemas/login-user+v1.js
@@ -15,6 +15,19 @@ export default {
       description: 'User password',
       minLength: 6,
     },
+    scopes: {
+      oneOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      ],
+    },
   },
-  required: ['email', 'password'],
+  required: ['email', 'password', 'scopes'],
 };

--- a/src/func/auth/register.js
+++ b/src/func/auth/register.js
@@ -64,6 +64,7 @@ async function createUser(req) {
     Content: {
       email: data.email,
       password: hashedPassword,
+      scopes: 'user:profile create:chat read:chat',
     },
   };
 

--- a/src/func/auth/tests/__snapshots__/login.test.js.snap
+++ b/src/func/auth/tests/__snapshots__/login.test.js.snap
@@ -2,11 +2,8 @@
 
 exports[`Login Controller can get user by their email 1`] = `
 Object {
-  "Content": Object {
-    "email": "validEmail@example.com",
-    "password": "validPassword",
-  },
-  "Path": "user/validEmail@example.com",
+  "email": "validEmail@example.com",
+  "password": "validPassword",
 }
 `;
 
@@ -15,7 +12,6 @@ Object {
   "body": Object {
     "data": Object {
       "attributes": Object {
-        "email": "validEmail@example.com",
         "expireAt": "123456",
         "token": "Berear mockToken",
       },

--- a/src/func/auth/tests/login.test.js
+++ b/src/func/auth/tests/login.test.js
@@ -19,6 +19,7 @@ describe('Login Controller', () => {
         data: {
           email: 'validEmail@example.com',
           password: 'validPassword',
+          scopes: 'user:profile create:chat read:chat',
         },
       },
       instrumentation: {
@@ -136,11 +137,8 @@ describe('Login Controller', () => {
         },
       },
       user: {
-        Path: 'user/validEmail@example.com',
-        Content: {
-          email: 'validEmail@example.com',
-          password: 'hashedPassword',
-        },
+        email: 'validEmail@example.com',
+        password: 'hashedPassword',
       },
       instrumentation: {
         error: jest.fn(),
@@ -162,11 +160,8 @@ describe('Login Controller', () => {
         },
       },
       user: {
-        Path: 'user/validEmail@example.com',
-        Content: {
-          email: 'validEmail@example.com',
-          password: 'notCorrect',
-        },
+        email: 'validEmail@example.com',
+        password: 'notCorrect',
       },
       instrumentation: {
         error: jest.fn(),
@@ -191,14 +186,13 @@ describe('Login Controller', () => {
         data: {
           email: 'validEmail@example.com',
           password: 'validPassword',
+          scopes: 'user:profile create:chat read:chat',
         },
       },
       user: {
-        Path: 'user/validEmail@example.com',
-        Content: {
-          email: 'validEmail@example.com',
-          password: 'notCorrect',
-        },
+        email: 'validEmail@example.com',
+        password: 'notCorrect',
+        scopes: 'user:profile create:chat read:chat',
       },
     };
 
@@ -206,6 +200,34 @@ describe('Login Controller', () => {
 
     expect(state).toHaveProperty('token');
     expect(state).toHaveProperty('expireAt');
+  });
+
+  it('can generate token for specified user', () => {
+    const request = {
+      body: {
+        data: {
+          email: 'validEmail@example.com',
+          password: 'validPassword',
+          scopes: 'user:profile create:chat read:chat delete:user',
+        },
+      },
+      user: {
+        email: 'validEmail@example.com',
+        password: 'notCorrect',
+        scopes: 'user:profile create:chat read:chat',
+      },
+    };
+
+    let error;
+
+    try {
+      generateToken(request);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeDefined();
+    expect(error).toBeInstanceOf(BadRequestError);
   });
 
   it('can return response correctly', () => {
@@ -234,6 +256,7 @@ describe('Login Controller', () => {
         data: {
           email: 'validEmail@example.com',
           password: 'validPassword',
+          scopes: 'user:profile create:chat read:chat',
         },
       },
       instrumentation: {

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -108,6 +108,18 @@ class UnauthorizedError extends JsonApiError {
   }
 }
 
+class ForbiddenError extends JsonApiError {
+  constructor() {
+    const forbiddenError = {
+      title: 'ForbiddenError',
+      code: 'ForbiddenError',
+      status: 403,
+      detail: 'ForbiddenError.',
+    };
+    super(forbiddenError);
+  }
+}
+
 export {
   InternalError,
   NotFoundError,
@@ -115,4 +127,5 @@ export {
   MalformedError,
   TimeoutError,
   UnauthorizedError,
+  ForbiddenError,
 };

--- a/src/lib/jwtPassport.js
+++ b/src/lib/jwtPassport.js
@@ -9,15 +9,25 @@ export default function jwtPassport(passport) {
 
   passport.use(new JwtStrategy(options, (jwtPayload, done) => {
     const {
-      _doc: {
-        Path,
-      },
+      userEmail,
+      scopes,
     } = jwtPayload;
+
     storageLibrary.findOne({
-      Path,
-    }).then((user) => {
-      if (user) done(null, user);
-      done(null, false);
+      Path: `user/${userEmail}`,
+    }).then((record) => {
+      if (record) {
+        const {
+          Content: {
+            password,
+            ...userAttributesWithoutPassword
+          },
+        } = record;
+        done(null, {
+          ...userAttributesWithoutPassword,
+          scopes,
+        });
+      } else done(null, false);
     }).catch(error => done(error, false));
   }));
 }

--- a/src/lib/middlewares/index.js
+++ b/src/lib/middlewares/index.js
@@ -1,5 +1,7 @@
 import malformedErrorHandler from './malformedErrorHandler';
+import jwtAuthz from './jwtAuthz';
 
 export {
   malformedErrorHandler,
+  jwtAuthz,
 };

--- a/src/lib/middlewares/jwtAuthz.js
+++ b/src/lib/middlewares/jwtAuthz.js
@@ -1,0 +1,36 @@
+import { intersection } from 'lodash';
+import { ForbiddenError } from '../errors';
+
+const checkScopes = (grantedScopes, apiScopes) => {
+  const wantedScopes = Array.isArray(apiScopes) ? apiScopes : apiScopes.split(' ');
+
+  if (wantedScopes.length > grantedScopes.length) {
+    throw new ForbiddenError();
+  }
+  if (intersection(grantedScopes, wantedScopes) < wantedScopes.length) {
+    throw new ForbiddenError();
+  }
+
+  return true;
+};
+
+export default function jwtAuthz(req, res, next) {
+  return function (apiScopes) {
+    const grantedScopes = req.user.scopes;
+
+    try {
+      checkScopes(grantedScopes, apiScopes);
+      next();
+    } catch (error) {
+      if (error instanceof ForbiddenError) {
+        const e = error.toJSON();
+
+        res.status(e.status).json(
+          {
+            errors: [e],
+          },
+        );
+      }
+    }
+  };
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,4 +1,5 @@
 import { login, register } from './func/auth';
+import { jwtAuthz } from './lib/middlewares';
 
 const routes = [
   {
@@ -22,11 +23,11 @@ const routes = [
   {
     path: '/private',
     method: 'GET',
-    controller: () => ({
+    controller: req => ({
       statusCode: 200,
-      body: {},
+      body: req.user,
     }),
-    middlewares: [],
+    middlewares: [(req, res, next) => jwtAuthz(req, res, next)(['user:profile'])],
     meta: {
       isProtected: true,
     },


### PR DESCRIPTION
- Add `scopes` into JWT claims.
- Strict authorization in API
- Fix: jwtPassport middlewares doesn't work correclty